### PR TITLE
Fix the req_attribute to send 2 strings, and allow multiple req_attribute in the request.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,17 @@
-/target
-/.classpath
-/.project
-/.settings
-/.pydevproject
+target/
+.pydevproject
+
+# Eclipse project files
+.classpath
+.project
+.settings
+.externalToolBuilders
+
+# IntelliJ project files
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# IntelliJ plugin files
+atlassian-ide-plugin.xml

--- a/pom.xml
+++ b/pom.xml
@@ -46,9 +46,9 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.7</java.version>
     <netty.version>4.1.0.CR6</netty.version>
-    <spring.version>4.2.5.RELEASE</spring.version>
-    <tomcat.version>8.5.0</tomcat.version>
-    <slf4j.version>1.7.21</slf4j.version>
+    <spring.version>4.3.13.RELEASE</spring.version>
+    <tomcat.version>8.5.2</tomcat.version>
+    <slf4j.version>1.7.25</slf4j.version>
     <maven.jacoco.version>0.7.2.201409121644</maven.jacoco.version>
   </properties>
   <repositories>
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.1.2</version>
+      <version>1.1.11</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -312,7 +312,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.5</version>
+            <version>1.6</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -334,7 +334,7 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.3</version>
+            <version>1.6.8</version>
             <extensions>true</extensions>
             <configuration>
               <serverId>sonatype-nexus-staging</serverId>

--- a/src/main/java/com/github/jrialland/ajpclient/Attribute.java
+++ b/src/main/java/com/github/jrialland/ajpclient/Attribute.java
@@ -1,5 +1,5 @@
 /* Copyright (c) 2014-2017 Julien Rialland <julien.rialland@gmail.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -9,44 +9,27 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  */
 package com.github.jrialland.ajpclient;
 
-/**
- * ajp13 forward request attributes. these are optional key/values that can be
- * sent with forward requests.
- *
- * @author Julien Rialland <julien.rialland@gmail.com>
- *
- */
-public enum Attribute {
+import java.util.List;
 
-	// @formatter:off
-	context(0x01), // unused
-	servlet_path(0x02), // unused
-	remote_user(0x03), auth_type(0x04), query_string(0x05), route(0x06), ssl_cert(0x07), ssl_cipher(0x08), ssl_session(0x09), req_attribute(
-			0x0A), ssl_key_size(0x0B), secret(0x0C), stored_method(0x0D);
-	// @formatter:on
+public final class Attribute {
 
-	private final int code;
+  private AttributeType type;
+  private List<String> value;
 
-	Attribute(final int code) {
-		this.code = code;
-	}
+  public Attribute(final AttributeType type, final List<String> value) {
+    this.type = type;
+    this.value = value;
+  }
 
-	public int getCode() {
-		return code;
-	};
+  public AttributeType getType() {
+    return type;
+  }
 
-	/**
-	 *
-	 * @param key
-	 *            attribute key
-	 * @return the corresponding code.
-	 */
-	public static Integer getCode(final String key) {
-		final Attribute attr = Attribute.valueOf(key);
-		return attr == null ? null : attr.getCode();
-	}
+  public List<String> getValue() {
+    return value;
+  }
 }

--- a/src/main/java/com/github/jrialland/ajpclient/AttributeType.java
+++ b/src/main/java/com/github/jrialland/ajpclient/AttributeType.java
@@ -1,0 +1,52 @@
+/* Copyright (c) 2014-2017 Julien Rialland <julien.rialland@gmail.com>
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package com.github.jrialland.ajpclient;
+
+/**
+ * ajp13 forward request attributes. these are optional key/values that can be
+ * sent with forward requests.
+ *
+ * @author Julien Rialland <julien.rialland@gmail.com>
+ *
+ */
+public enum AttributeType {
+
+	// @formatter:off
+	context(0x01), // unused
+	servlet_path(0x02), // unused
+	remote_user(0x03), auth_type(0x04), query_string(0x05), route(0x06), ssl_cert(0x07), ssl_cipher(0x08), ssl_session(0x09), req_attribute(
+			0x0A), ssl_key_size(0x0B), secret(0x0C), stored_method(0x0D);
+	// @formatter:on
+
+	private final int code;
+
+	AttributeType(final int code) {
+		this.code = code;
+	}
+
+	public int getCode() {
+		return code;
+	};
+
+	/**
+	 *
+	 * @param key
+	 *            attribute key
+	 * @return the corresponding code.
+	 */
+	public static Integer getCode(final String key) {
+		final AttributeType attr = AttributeType.valueOf(key);
+		return attr == null ? null : attr.getCode();
+	}
+}

--- a/src/main/java/com/github/jrialland/ajpclient/ForwardRequest.java
+++ b/src/main/java/com/github/jrialland/ajpclient/ForwardRequest.java
@@ -15,7 +15,7 @@ package com.github.jrialland.ajpclient;
 
 import java.io.InputStream;
 import java.util.Collection;
-import java.util.Map;
+import java.util.List;
 
 import com.github.jrialland.ajpclient.impl.enums.RequestMethod;
 
@@ -47,7 +47,7 @@ public interface ForwardRequest {
 
 	Collection<Header> getHeaders();
 
-	Map<Attribute, String> getAttributes();
+	List<Attribute> getAttributes();
 
 	InputStream getRequestBody();
 }

--- a/src/main/java/com/github/jrialland/ajpclient/SimpleForwardRequest.java
+++ b/src/main/java/com/github/jrialland/ajpclient/SimpleForwardRequest.java
@@ -17,9 +17,8 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
 
 import com.github.jrialland.ajpclient.impl.enums.RequestMethod;
 
@@ -43,7 +42,7 @@ public class SimpleForwardRequest implements ForwardRequest {
 
 	List<Header> headers = new ArrayList<Header>();
 
-	private Map<Attribute, String> attributes = new TreeMap<Attribute, String>();
+	private List<Attribute> attributes = new ArrayList<>();
 
 	private InputStream requestBody;
 
@@ -60,7 +59,7 @@ public class SimpleForwardRequest implements ForwardRequest {
 		this.method = RequestMethod.forMethod(method);
 		if (this.method == null) {
 			this.method = RequestMethod.JK_STORED;
-			attributes.put(Attribute.stored_method, method);
+			attributes.add(new Attribute(AttributeType.stored_method, Collections.singletonList(method)));
 		}
 	}
 
@@ -119,11 +118,11 @@ public class SimpleForwardRequest implements ForwardRequest {
 	}
 
 	@Override
-	public Map<Attribute, String> getAttributes() {
+	public List<Attribute> getAttributes() {
 		return attributes;
 	}
 
-	public void setAttributes(final Map<Attribute, String> attributes) {
+	public void setAttributes(final List<Attribute> attributes) {
 		this.attributes = attributes;
 	}
 

--- a/src/main/java/com/github/jrialland/ajpclient/impl/ForwardImpl.java
+++ b/src/main/java/com/github/jrialland/ajpclient/impl/ForwardImpl.java
@@ -1,5 +1,5 @@
 /* Copyright (c) 2014-2017 Julien Rialland <julien.rialland@gmail.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -9,12 +9,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  */
 package com.github.jrialland.ajpclient.impl;
-
-import io.netty.buffer.ByteBuf;
-import io.netty.channel.Channel;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
@@ -22,7 +19,6 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
-import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -34,6 +30,8 @@ import com.github.jrialland.ajpclient.Header;
 import com.github.jrialland.ajpclient.impl.enums.RequestHeader;
 import com.github.jrialland.ajpclient.pool.Buffers;
 import com.github.jrialland.ajpclient.pool.ChannelCallback;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
 
 /**
  * Forward conversion : the client forwards an http request to server.
@@ -143,9 +141,11 @@ public class ForwardImpl extends Conversation implements ChannelCallback, Consta
 		}
 
 		// attributes
-		for (final Entry<Attribute, String> attr : request.getAttributes().entrySet()) {
-			tmp.writeByte(attr.getKey().getCode());
-			writeString(attr.getValue(), tmp);
+		for (final Attribute attr : request.getAttributes()) {
+			tmp.writeByte(attr.getType().getCode());
+			for(String value: attr.getValue()) {
+				writeString(value, tmp);
+			}
 		}
 
 		// request terminator

--- a/src/main/java/com/github/jrialland/ajpclient/servlet/AjpServletProxy.java
+++ b/src/main/java/com/github/jrialland/ajpclient/servlet/AjpServletProxy.java
@@ -18,12 +18,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
 import javax.servlet.ServletException;
@@ -35,6 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.jrialland.ajpclient.Attribute;
+import com.github.jrialland.ajpclient.AttributeType;
 import com.github.jrialland.ajpclient.Forward;
 import com.github.jrialland.ajpclient.ForwardRequest;
 import com.github.jrialland.ajpclient.ForwardResponse;
@@ -63,7 +63,7 @@ public class AjpServletProxy {
 
 		private final List<Header> headers = new LinkedList<Header>();
 
-		private final Map<Attribute, String> attributes = new TreeMap<Attribute, String>();
+		private final List<Attribute> attributes = new ArrayList<>();
 
 		public RequestWrapper(final HttpServletRequest request) throws IOException {
 
@@ -72,7 +72,7 @@ public class AjpServletProxy {
 			requestMethod = RequestMethod.forMethod(request.getMethod());
 			if (requestMethod == null) {
 				requestMethod = RequestMethod.JK_STORED;
-				attributes.put(Attribute.stored_method, request.getMethod());
+				attributes.add(new Attribute(AttributeType.stored_method, Collections.singletonList(request.getMethod())));
 			}
 
 			boolean hasContentLength = false;
@@ -90,14 +90,14 @@ public class AjpServletProxy {
 			}
 
 			if (request.getQueryString() != null) {
-				attributes.put(Attribute.query_string, request.getQueryString());
+				attributes.add(new Attribute(AttributeType.query_string, Collections.singletonList(request.getQueryString())));
 			}
 
 			if (request.getRemoteUser() != null) {
-				attributes.put(Attribute.remote_user, request.getRemoteUser());
+				attributes.add(new Attribute(AttributeType.remote_user, Collections.singletonList(request.getRemoteUser())));
 			}
 
-			attributes.put(Attribute.servlet_path, request.getServletPath());
+			attributes.add(new Attribute(AttributeType.servlet_path, Collections.singletonList(request.getServletPath())));
 
 			in = new BufferedInputStream(request.getInputStream());
 		}
@@ -143,7 +143,7 @@ public class AjpServletProxy {
 		}
 
 		@Override
-		public Map<Attribute, String> getAttributes() {
+		public List<Attribute> getAttributes() {
 			return attributes;
 		}
 


### PR DESCRIPTION
I use the ajp_client to send requests to my Spring Boot application with Embedded Tomcat. I wanted to use the AJP_LOCAL_ADDR, AJP_REMOTE_PORT and AJP_SSL_PROTOCOL attribute with some values. For the req_attribute (0x0A) attribute, the value is actually 2 strings. The first is the name, the second is the value. I renamed the Attribute to AttributeType, and refactored the Map to a List of Attribute objects. Then the code worked to the Tomcat AJP/1.3 connector and the remote port, and localaddress are available in the servlet request.